### PR TITLE
linter.ymlでのSuper Linterのslim v4指定を公式ドキュメントの最新記法に修正 (#123)

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -48,8 +48,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        # uses: github/super-linter@v4
-        uses: docker://ghcr.io/github/super-linter:slim-v4 # See https://github.com/github/super-linter#images
+        uses: github/super-linter:slim-v4 # See https://github.com/github/super-linter#images
         env:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_JAVASCRIPT_ES: true


### PR DESCRIPTION
resolve #123 